### PR TITLE
Update .spi.yml

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -2,4 +2,4 @@ version: 1
 builder:
   configs:
     - platform: ios
-      documentation_targets: [NiftyMarkdownFormatter]
+      documentation_targets: ["Nifty Markdown Formatter"]


### PR DESCRIPTION
This should fix the documentation in the Swift Package Index. We're actually using the scheme if the docs are generated via Xcode instead of SPM, and iOS builds happen via Xcode.