### PR TITLE
Add support for tvOS and watchOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,9 @@ let package = Package(
     name: "Nifty Markdown Formatter",
     platforms: [
         .iOS(.v14),
-        .macOS(.v11)
+        .macOS(.v11),
+        .tvOS(.v15),
+        .watchOS(.v8)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.


### PR DESCRIPTION
I added the tvOS and watchOS platforms to be able to compile this package inside of Swift Multiplatform project. 

Note: I didn't check how the library is behaving on tvOS/watchOS.